### PR TITLE
fix(deps): bump axios from 1.11.0 to 1.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@tazama-lf/frms-coe-lib": "5.1.0",
-        "axios": "^1.10.0",
+        "axios": "^1.12.0",
         "dotenv": "^17.2.0",
         "node-cache": "^5.1.2",
         "tslib": "^2.8.1"
@@ -2978,9 +2978,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.11.0.tgz",
-      "integrity": "sha512-1Lx3WLFQWm3ooKDYZD1eXmoGO9fxYQjrycfHFC8P0sCfQVXyROp0p9PFWBehewBOdCwHc+f/b8I0fMto5eSfwA==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
+      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "homepage": "https://github.com/tazama-lf/relay-service-integration-rest#readme",
   "dependencies": {
     "@tazama-lf/frms-coe-lib": "5.1.0",
-    "axios": "^1.10.0",
+    "axios": "^1.12.0",
     "dotenv": "^17.2.0",
     "node-cache": "^5.1.2",
     "tslib": "^2.8.1"


### PR DESCRIPTION
## What did we change?
Dependency update

## Why are we doing this?

## How was it tested?
- [x] Locally
- [x] Development Environment
- [x] Not needed, changes very basic
- [x] Husky successfully run
- [x] Unit tests passing and Documentation done
